### PR TITLE
add scripts to export MuckRock IDs & info to JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 *.DS_Store
 .DS_Store
+agencies/
+exemptions/
+jurisdictions/

--- a/export_agencies.py
+++ b/export_agencies.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python2
+# -- coding: utf-8 --
+
+import utils
+import urllib, os, json, datetime, requests, urlparse
+
+api_url = utils.API_URL
+token = utils.get_api_key()
+headers = utils.get_headers(token)
+
+page = 1
+next_url = api_url + "agency/?page=" + str(page)
+done_so_far = 0
+
+
+try:
+    os.mkdir('agencies')
+except Exception as e:
+    print 'dir exists'
+
+while next_url:
+    agencies = requests.get(next_url , headers=headers).json()
+    agency_data = agencies['results']
+    for agency in agency_data:
+        text_file = open('agencies/' + str(agency["id"]) + ".json", "w+")
+        text_file.write(json.dumps(agency, sort_keys=True, indent=4, separators=(',', ': ')))
+        text_file.close()
+
+    done_so_far = done_so_far + len(agency_data)
+    count = agencies['count']
+    print 'Getting agencies: %d of %d' % (done_so_far, count)
+    next_url = agencies['next']

--- a/export_exemptions.py
+++ b/export_exemptions.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python2
+# -- coding: utf-8 --
+
+import utils
+import urllib, os, json, datetime, requests, urlparse
+
+api_url = utils.API_URL
+token = utils.get_api_key()
+headers = utils.get_headers(token)
+
+page = 1
+next_url = api_url + "exemption/?page=" + str(page)
+done_so_far = 0
+
+try:
+    os.mkdir('exemptions')
+except Exception as e:
+    print 'dir exists'
+
+while next_url:
+    exemptions = requests.get(next_url , headers=headers).json()
+    exemption_data = exemptions['results']
+    for exemption in exemption_data:
+        text_file = open('exemptions/' + str(exemption["id"]) + ".json", "w+")
+        text_file.write(json.dumps(exemption, sort_keys=True, indent=4, separators=(',', ': ')))
+        text_file.close()
+
+    done_so_far = done_so_far + len(exemption_data)
+    count = exemptions['count']
+    print 'Getting exemptions: %d of %d' % (done_so_far, count)
+    next_url = exemptions['next']

--- a/export_jurisdictions.py
+++ b/export_jurisdictions.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python2
+# -- coding: utf-8 --
+
+import utils
+import urllib, os, json, datetime, requests, urlparse
+
+api_url = utils.API_URL
+token = utils.get_api_key()
+headers = utils.get_headers(token)
+
+page = 1
+next_url = api_url + "jurisdiction/?page=" + str(page)
+done_so_far = 0
+
+try:
+    os.mkdir('jurisdictions')
+except Exception as e:
+    print 'dir exists'
+
+while next_url:
+    jurisdictions = requests.get(next_url , headers=headers).json()
+    jurisdiction_data = jurisdictions['results']
+    for jurisdiction in jurisdiction_data:
+        text_file = open('jurisdictions/' + str(jurisdiction["id"]) + ".json", "w+")
+        text_file.write(json.dumps(jurisdiction, sort_keys=True, indent=4, separators=(',', ': ')))
+        text_file.close()
+
+    done_so_far = done_so_far + len(jurisdiction_data)
+    count = jurisdictions['count']
+    print 'Getting jurisdictions: %d of %d' % (done_so_far, count)
+    next_url = jurisdictions['next']

--- a/export_muckrock_identifiers.py
+++ b/export_muckrock_identifiers.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python2
+# -- coding: utf-8 --
+
+import export_agencies, export_exceptions, export_jurisdictions


### PR DESCRIPTION
Useful to have locally, e.g. to reduce overhead of repeated requests for agency info, or to make multirequests to agencies with specific properties (e.g. federal is `"jurisdiction": 10`; non-appeals requires getting all the appeal_agency IDs and removing the referents).

No clear way yet to filter out courts (which aren't under real FOIA), or geographic branches (without filtering out component agencies).

Agencies: 12,882 (51 MB)
Exemptions: 204 (1 MB)
Jurisdictions: 33,618 (132 MB)